### PR TITLE
Fix XSS vector in notfound.html

### DIFF
--- a/html/notfound.html
+++ b/html/notfound.html
@@ -5,11 +5,11 @@
 
 {% block body %}
 
-<p class="alert">{{ message }}</p>
+<p class="alert">{{ message | escape }}</p>
 
 <p>The URL
 
-<code>{{ getCurrentEditableUrl() }}</code>
+<code>{{ getCurrentEditableUrl() | escape }}</code>
 
 was not found.
 </p>


### PR DESCRIPTION
For example (FF only):

go/%3Cimg%20src=x%20onerror=%22alert%60xss%60%22%3E